### PR TITLE
Update dependancy for webpack supprt

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/soplakanets/node-forecastio",
   "dependencies": {
-    "request-promise": "^3.0.0"
+    "request-promise": "^4.1.1"
   },
   "devDependencies": {
     "mocha": "^2.5.3"


### PR DESCRIPTION
to pack this into the web using webpack or browserify the dependency `request-promise < 4.0.0 ` throws a `cannot resolve module module 'cls-bluebird'` error. 
I just updated the `request-promise to 4.1.1 `
more info : [issue#91](https://github.com/request/request-promise/issues/91)